### PR TITLE
主页面右侧两个静态图

### DIFF
--- a/src/components/card/ChartCard.vue
+++ b/src/components/card/ChartCard.vue
@@ -56,7 +56,7 @@ export default {
     margin-bottom: 0;
     font-size: 30px;
     line-height: 38px;
-    height: 50px;
+    height: 80px;
   }
   .chart-card-footer{
     border-top: 1px solid @border-color-base;

--- a/src/components/card/ChartCard.vue
+++ b/src/components/card/ChartCard.vue
@@ -37,9 +37,9 @@ export default {
     position: relative;
     overflow: hidden;
     width: 100%;
-    color: @text-color-second;
-    font-size: 14px;
-    line-height: 22px;
+    color: '#F56F53';
+    font-size: 16px;
+    line-height: 16px;
   }
   .chart-card-action{
     cursor: pointer;
@@ -52,19 +52,19 @@ export default {
     text-overflow: ellipsis;
     word-break: break-all;
     white-space: nowrap;
-    margin-top: 4px;
+    margin-top: 0px;
     margin-bottom: 0;
     font-size: 30px;
     line-height: 38px;
-    height: 38px;
+    height: 50px;
   }
   .chart-card-footer{
     border-top: 1px solid @border-color-base;
-    padding-top: 9px;
-    margin-top: 8px;
+    padding-top: 0px;
+    margin-top: 0px;
   }
   .chart-card-content{
-    margin-bottom: 12px;
+    margin-bottom: 20px;
     position: relative;
     height: 46px;
     width: 100%;

--- a/src/components/chart/myBar.vue
+++ b/src/components/chart/myBar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="mini-chart">
     <div class="chart-content" :style="{height: 25}">
-      <v-chart :force-fit="true" :height="height" :data="data" :padding="[8, 0, 65, 22.3]">
+      <v-chart :force-fit="true" :height="height" :data="data" :padding="[5, 18, 65, 22.3]">
         <v-tooltip />
         <v-legend />
         <v-axis />
@@ -58,15 +58,15 @@ export default {
   const DataSet = require('@antv/data-set');
 
   const sourceData = [
-    { name: '闲置状态', '西大五-1.0m': 11, '3701': 21, '2501': 22, '西大五-1.6m': 23, '西17-1.6m': 22, '西1.6m': 25, '主斜井': 17 },
-    { name: '通讯故障', '西大五-1.0m': 20, '3701': 23, '2501': 29, '西大五-1.6m': 27, '西17-1.6m': 29, '西1.6m': 21, '主斜井': 27 },
-    { name: '其他故障', '西大五-1.0m': 18, '3701': 28, '2501': 15, '西大五-1.6m': 21, '西17-1.6m': 24, '西1.6m': 28, '主斜井': 24 },
+    { name: '闲置状态', '西大五-1.0m': 11, '3701': 21, '2501': 22, '西大五-1.6m': 23, '西17-1.6m': 22, '西1.6m': 25 },
+    { name: '通讯故障', '西大五-1.0m': 20, '3701': 23, '2501': 29, '西大五-1.6m': 27, '西17-1.6m': 29, '西1.6m': 21 },
+    { name: '其他故障', '西大五-1.0m': 18, '3701': 28, '2501': 15, '西大五-1.6m': 21, '西17-1.6m': 24, '西1.6m': 28 },
   ];
 
   const dv = new DataSet.View().source(sourceData);
   dv.transform({
     type: 'fold',
-    fields: ['西大五-1.0m', '3701', '2501', '西大五-1.6m', '西17-1.6m', '西1.6m', '主斜井'],
+    fields: ['西大五-1.0m', '3701', '2501', '西大五-1.6m', '西17-1.6m', '西1.6m'],
     key: 'x',
     value: 'y',
   });

--- a/src/components/chart/myBar.vue
+++ b/src/components/chart/myBar.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="mini-chart">
+    <div class="chart-content" :style="{height: 25}">
+      <v-chart :force-fit="true" :height="height" :data="data" :padding="[8, 0, 65, 22.3]">
+        <v-tooltip />
+        <v-legend />
+        <v-axis />
+        <v-bar position="x*y" color="name" :adjust="adjust" />
+      </v-chart>
+    </div>
+  </div>
+</template>
+
+<script>
+/*
+import {format} from 'date-fns'
+
+const data = []
+const beginDay = new Date().getTime()
+
+const fakeY = [7, 5, 4, 2, 4, 7, 5, 6, 5, 9, 6, 3, 1, 5, 3, 6, 5]
+for (let i = 0; i < fakeY.length; i += 1) {
+  data.push({
+    x: format(new Date(beginDay + 1000 * 60 * 60 * 24 * i), 'yyyy-MM-dd'),
+    y: fakeY[i]
+  })
+}
+
+const tooltip = [
+  'x*y',
+  (x, y) => ({
+    name: x,
+    value: y
+  })
+]
+
+const scale = [{
+  dataKey: 'x',
+  min: 2
+}, {
+  dataKey: 'y',
+  title: '时间',
+  min: 1,
+  max: 22
+}]
+
+export default {
+  name: 'MiniBar',
+  data () {
+    return {
+      data,
+      scale,
+      tooltip,
+      height: 100
+    }
+  }
+}*/
+  const DataSet = require('@antv/data-set');
+
+  const sourceData = [
+    { name: '闲置状态', '西大五-1.0m': 11, '3701': 21, '2501': 22, '西大五-1.6m': 23, '西17-1.6m': 22, '西1.6m': 25, '主斜井': 17 },
+    { name: '通讯故障', '西大五-1.0m': 20, '3701': 23, '2501': 29, '西大五-1.6m': 27, '西17-1.6m': 29, '西1.6m': 21, '主斜井': 27 },
+    { name: '其他故障', '西大五-1.0m': 18, '3701': 28, '2501': 15, '西大五-1.6m': 21, '西17-1.6m': 24, '西1.6m': 28, '主斜井': 24 },
+  ];
+
+  const dv = new DataSet.View().source(sourceData);
+  dv.transform({
+    type: 'fold',
+    fields: ['西大五-1.0m', '3701', '2501', '西大五-1.6m', '西17-1.6m', '西1.6m', '主斜井'],
+    key: 'x',
+    value: 'y',
+  });
+  const data = dv.rows;
+
+  export default {
+    data() {
+      return {
+        data,
+        height: 110,
+        adjust: [{
+          type: 'dodge',
+          marginRatio: 1 / 32,
+        }],
+      };
+    }
+  }
+</script>
+
+<style lang="less" scoped>
+@import "index.less";
+</style>

--- a/src/components/chart/myLine.vue
+++ b/src/components/chart/myLine.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="mini-chart">
+    <div class="chart-content" :style="{height: 25}">
+      <v-chart :force-fit="true" :height="height" :data="data" :padding="[276, 18, 65, 29.3]">
+        <v-tooltip />
+        <v-legend />
+        <v-axis />
+        <v-smooth-line position="month*temperature" color="city" shape="smooth" />
+        <v-point position="month*temperature" color="city" shape="circle" />
+      </v-chart>
+    </div>
+  </div>
+</template>
+
+<script>
+const DataSet = require('@antv/data-set');
+
+const sourceData = [
+  { month: '7/1', '西大五-1.0m': 0.94, '3701': 0.96, '2501': 0.82, '西大五-1.6m': 0.87, '西17-1.6m': 0.85, '西1.6m': 0.87 },
+  { month: '7/2', '西大五-1.0m': 0.91, '3701': 0.81, '2501': 0.75, '西大五-1.6m': 0.86, '西17-1.6m': 0.90, '西1.6m': 0.93 },
+  { month: '7/3', '西大五-1.0m': 0.52, '3701': 0.75, '2501': 0.52, '西大五-1.6m': 0.89, '西17-1.6m': 0.89, '西1.6m': 0.92 },
+  { month: '7/4', '西大五-1.0m': 0.45, '3701': 0.53, '2501': 0.78, '西大五-1.6m': 0.99, '西17-1.6m': 0.84, '西1.6m': 0.95 },
+  { month: '7/5', '西大五-1.0m': 0.43, '3701': 0.95, '2501': 0.97, '西大五-1.6m': 0.65, '西17-1.6m': 0.97, '西1.6m': 0.91 },
+  { month: '7/6', '西大五-1.0m': 0.55, '3701': 0.84, '2501': 0.91, '西大五-1.6m': 0.76, '西17-1.6m': 0.85, '西1.6m': 0.90 },
+  { month: '7/7', '西大五-1.0m': 0.29, '3701': 0.93, '2501': 0.83, '西大五-1.6m': 0.78, '西17-1.6m': 0.98, '西1.6m': 0.94 },
+  { month: '7/8', '西大五-1.0m': 0.53, '3701': 0.62, '2501': 0.96, '西大五-1.6m': 0.89, '西17-1.6m': 0.96, '西1.6m': 0.83 },
+  { month: '7/9', '西大五-1.0m': 0.37, '3701': 0.81, '2501': 0.94, '西大五-1.6m': 0.95, '西17-1.6m': 0.91, '西1.6m': 0.81 },
+  { month: '7/10', '西大五-1.0m': 0.45, '3701': 0.39, '2501': 0.85, '西大五-1.6m': 0.92, '西17-1.6m': 0.84, '西1.6m': 0.88 }
+];
+// , Tokyo: 0.94, London: 0.96, Tokyo: 0.94, London: 0.96, Tokyo: 0.94
+const dv = new DataSet.View().source(sourceData);
+dv.transform({
+  type: 'fold',
+  fields: ['西大五-1.0m', '3701', '2501', '西大五-1.6m', '西17-1.6m', '西1.6m'],
+  key: 'city',
+  value: 'temperature',
+});
+const data = dv.rows;
+
+const scale = [{
+  dataKey: 'month',
+  min: 0,
+  max: 1,
+}];
+
+export default {
+  data() {
+    return {
+      data,
+      scale,
+      height: 400,
+    };
+  }
+};
+</script>
+
+<style lang="less" scoped>
+@import "index.less";
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -11,10 +11,12 @@ import Plugins from '@/plugins'
 import {initI18n} from '@/utils/i18n'
 import bootstrap from '@/bootstrap'
 import 'moment/locale/zh-cn'
+import echarts from 'echarts'
 
 const router = initRouter(store.state.setting.asyncRoutes)
 const i18n = initI18n('CN', 'US')
 
+// Vue.prototype.echarts = echarts
 Vue.use(Antd)
 Vue.config.productionTip = false
 Vue.use(Viser)

--- a/src/pages/dashboard/analysis/Analysis.vue
+++ b/src/pages/dashboard/analysis/Analysis.vue
@@ -12,12 +12,12 @@
         </chart-card>
       </a-col>
       <a-col :sm="24" :md="12" :xl="12">
-        <chart-card :loading="loading" :title="$t('visits')" total="￥ 189,345">
+        <chart-card :loading="loading" :title="'单皮带传送效率(10天)'">
           <a-tooltip :title="$t('introduce')" slot="action">
             <a-icon type="info-circle-o" />
           </a-tooltip>
           <div>
-            <mini-area />
+            <my-line />
           </div>
         </chart-card>
       </a-col>
@@ -73,12 +73,12 @@
 
 <script>
 import ChartCard from '../../../components/card/ChartCard'
-import MiniArea from '../../../components/chart/MiniArea'
 import Bar from '../../../components/chart/Bar'
 import RankingList from '../../../components/chart/RankingList'
 import HotSearch from './HotSearch'
 import SalesData from './SalesData'
 import myBar from '../../../components/chart/myBar'
+import myLine from '../../../components/chart/myLine'
 
 const rankList = []
 
@@ -101,7 +101,7 @@ export default {
   created() {
     setTimeout(() => this.loading = !this.loading, 1000)
   },
-  components: {SalesData, HotSearch, RankingList, Bar, MiniArea, ChartCard, myBar}
+  components: {SalesData, HotSearch, RankingList, Bar, ChartCard, myBar, myLine}
 }
 </script>
 

--- a/src/pages/dashboard/analysis/Analysis.vue
+++ b/src/pages/dashboard/analysis/Analysis.vue
@@ -1,19 +1,17 @@
 <template>
   <div class="analysis">
     <a-row style="margin-top: 0" :gutter="[24, 24]">
-      <a-col :sm="24" :md="12" :xl="6">
-        <chart-card :loading="loading" :title="$t('totalSales')" total="￥ 189,345">
+      <a-col :sm="24" :md="12" :xl="12">
+        <chart-card :loading="loading" :title="'故障统计'">
           <a-tooltip :title="$t('introduce')" slot="action">
             <a-icon type="info-circle-o" />
           </a-tooltip>
           <div>
-            <trend style="margin-right: 16px" :term="$t('wow')" :percent="12" :is-increase="true" :scale="0" />
-            <trend :term="$t('dod')" :target="100" :value="89" :scale="0" />
+            <my-bar/>
           </div>
-          <div slot="footer">{{$ta('daily|sales', 'p')}}<span> ￥234.56</span></div>
         </chart-card>
       </a-col>
-      <a-col :sm="24" :md="12" :xl="6">
+      <a-col :sm="24" :md="12" :xl="12">
         <chart-card :loading="loading" :title="$t('visits')" total="￥ 189,345">
           <a-tooltip :title="$t('introduce')" slot="action">
             <a-icon type="info-circle-o" />
@@ -21,45 +19,15 @@
           <div>
             <mini-area />
           </div>
-          <div slot="footer">{{$ta('daily|visits', 'p')}}<span> 123,4</span></div>
-        </chart-card>
-      </a-col>
-      <a-col :sm="24" :md="12" :xl="6">
-        <chart-card :loading="loading" :title="$t('payments')" total="￥ 189,345">
-          <a-tooltip :title="$t('introduce')" slot="action">
-            <a-icon type="info-circle-o" />
-          </a-tooltip>
-          <div>
-            <mini-bar />
-          </div>
-          <div slot="footer">{{$t('conversion')}} <span>60%</span></div>
-        </chart-card>
-      </a-col>
-      <a-col :sm="24" :md="12" :xl="6">
-        <chart-card :loading="loading" :title="$t('operating')" total="73%">
-          <a-tooltip :title="$t('introduce')" slot="action">
-            <a-icon type="info-circle-o" />
-          </a-tooltip>
-          <div>
-            <mini-progress target="90" percent="78" color="#13C2C2" height="8px"/>
-          </div>
-          <div slot="footer" style="white-space: nowrap;overflow: hidden">
-            <trend style="margin-right: 16px" :term="$t('wow')" :percent="12" :is-increase="true" :scale="0" />
-            <trend :term="$t('dod')" :target="100" :value="89" :scale="0" />
-          </div>
         </chart-card>
       </a-col>
     </a-row>
-    <a-card :loading="loading" style="margin-top: 24px" :bordered="false" :body-style="{padding: '24px'}">
+
+    <a-card :loading="loading" style="margin-top: 48px" :bordered="false" :body-style="{padding: '24px'}">
       <div class="salesCard">
         <a-tabs default-active-key="1" size="large" :tab-bar-style="{marginBottom: '24px', paddingLeft: '16px'}">
           <div class="extra-wrap" slot="tabBarExtraContent">
-            <div class="extra-item">
-              <a>{{$t('day')}}</a>
-              <a>{{$t('week')}}</a>
-              <a>{{$t('month')}}</a>
-              <a>{{$t('year')}}</a>
-            </div>
+
             <a-range-picker :style="{width: '256px'}"></a-range-picker>
           </div>
           <a-tab-pane loading="true" :tab="$t('sales')" key="1">
@@ -106,13 +74,11 @@
 <script>
 import ChartCard from '../../../components/card/ChartCard'
 import MiniArea from '../../../components/chart/MiniArea'
-import MiniBar from '../../../components/chart/MiniBar'
-import MiniProgress from '../../../components/chart/MiniProgress'
 import Bar from '../../../components/chart/Bar'
 import RankingList from '../../../components/chart/RankingList'
 import HotSearch from './HotSearch'
 import SalesData from './SalesData'
-import Trend from '../../../components/chart/Trend'
+import myBar from '../../../components/chart/myBar'
 
 const rankList = []
 
@@ -135,7 +101,7 @@ export default {
   created() {
     setTimeout(() => this.loading = !this.loading, 1000)
   },
-  components: {Trend, SalesData, HotSearch, RankingList, Bar, MiniProgress, MiniBar, MiniArea, ChartCard}
+  components: {SalesData, HotSearch, RankingList, Bar, MiniArea, ChartCard, myBar}
 }
 </script>
 

--- a/src/pages/dashboard/analysis/Analysis.vue
+++ b/src/pages/dashboard/analysis/Analysis.vue
@@ -2,7 +2,7 @@
   <div class="analysis">
     <a-row style="margin-top: 0" :gutter="[24, 24]">
       <a-col :sm="24" :md="12" :xl="12">
-        <chart-card :loading="loading" :title="'故障统计'">
+        <chart-card :loading="loading" :title="'故障统计(10天)'">
           <a-tooltip :title="$t('introduce')" slot="action">
             <a-icon type="info-circle-o" />
           </a-tooltip>


### PR DESCRIPTION
原先计划引入 Echarts，但是网络一直 `GET Failed`， 因此画图采用了这个框架使用的图表组件 [Viser.js](https://viserjs.gitee.io/demo.html#/viser/event/use-label-desity)，原先框架引入 viser 的地方在 `src/main.js` 中的 `import Viser from 'viser-vue'`，不需要重新下载。
所修改的地方
- [x] 删除不需要的组表
- [x] 故障统计(10天)
- [x] 单皮带传送效率(10天)
- [ ] 美观程度 (此处修改了 `src\components\card\ChartCard.vue`)

还需要做：
- [ ] 整体布局，或者直接修改已有图表会更方便一些

